### PR TITLE
fix strudel-mode-if-appropriate to not return an error

### DIFF
--- a/strudel.el
+++ b/strudel.el
@@ -41,8 +41,9 @@
 (defun strudel-mode-if-appropriate ()
   "Enable strudel-mode if appropriate for the current buffer, i.e. its buffer-file-name has the extension `.strudel'."
   (interactive)
-  (when (string-match-p "\.strudel$" buffer-file-name)
-    (strudel-mode t)))
+  (and buffer-file-name
+       (string-match-p "\.strudel$" buffer-file-name)
+       (strudel-mode t)))
 
 (defun strudel-start ()
   "Start strudel."


### PR DESCRIPTION
When you add `strudel-mode-if-appropriate` to `js-mode-hook`, and run `js-mode` in scratch buffer or any buffer that doesn't have a file associated, an error is shown.
`string-match-p` inside the function matches a string against nil and throws an error.
I edited `strudel-mode-if-appropriate` to return nil if `buffer-file-name` is nil, so no errors will be returned.